### PR TITLE
MFM: Add port of the PC-BSD installer, pc-sysinstall.

### DIFF
--- a/sysutils/Makefile
+++ b/sysutils/Makefile
@@ -655,6 +655,7 @@
     SUBDIR += pax-utils
     SUBDIR += pbimaker
     SUBDIR += pbreg
+    SUBDIR += pc-sysinstall
     SUBDIR += pcfclock
     SUBDIR += pciutils
     SUBDIR += pcpustat

--- a/sysutils/pc-sysinstall/Makefile
+++ b/sysutils/pc-sysinstall/Makefile
@@ -1,0 +1,60 @@
+# Created by: bms
+# $FreeBSD$
+
+PORTNAME=	pc-sysinstall
+PORTVERSION=	9.1r${PSVN_REV}
+CATEGORIES=	sysutils
+MASTER_SITES=	LOCAL/bms
+
+MAINTAINER=	josh@ixsystems.com
+COMMENT=	PC-BSD system install utility
+
+LICENSE=	BSD
+
+PATCH_STRIP=	-p2
+USE_BZIP2=	yes
+
+MAN8=		${PORTNAME}.8
+MANCOMPRESSED=	yes
+
+ONLY_FOR_ARCH=	i386 amd64
+
+FSVN_REV=	243808
+PSVN_REV=	21630
+
+post-patch:
+	${RM} -f ${WRKSRC}/Makefile.inc
+	@${REINPLACE_CMD} -e 's|/usr|${LOCALBASE}|g' \
+	    ${WRKSRC}/pc-sysinstall/pc-sysinstall.sh
+
+do-build:
+	cd ${WRKSRC} && ${MAKE} DESTDIR=${PREFIX} SHAREDIR=/share BINDIR=/sbin MANDIR=/man/man
+
+do-install:
+	${MKDIR} ${DATADIR}
+	${MKDIR} ${EXAMPLESDIR}
+	${MTREE_CMD} -U -d -p ${DATADIR} -f ${FILESDIR}/pc-sysinstall.mtree
+	cd ${WRKSRC} && make install DESTDIR=${PREFIX} SHAREDIR=/share BINDIR=/sbin MANDIR=/man/man
+
+.if defined(BOOTSTRAP) || defined(SVN_FETCH)
+FETCH_DEPENDS+=		svn:${PORTSDIR}/devel/subversion
+
+FSVNPATH?=	http://svn.freebsd.org/base/release/9.1.0
+FSVNDIR=	usr.sbin/pc-sysinstall
+
+PSVNPATH?=	svn://trac.pcbsd.org/pcbsd/branches/9.1
+PSVNDIR=	build-files/src-patches
+PSVNFILE=	patch-pc-sysinstall-distfiles
+
+do-fetch:
+	${MKDIR} ${WRKDIR}
+	svn export -r ${FSVN_REV} ${FSVNPATH}/${FSVNDIR} ${WRKDIR}/${DISTNAME}
+	#svn export -r ${PSVN_REV} ${PSVNPATH}/${PSVNDIR}/${PSVNFILE} ${WRKDIR}/${PORTNAME}
+	cd ${WRKDIR}; tar cvfy ${DISTDIR}/${DISTNAME}.tar.bz2 ${DISTNAME}
+.if ${USER} == bmsNOTYET
+	scp ${DISTDIR}/${DISTNAME}.tar.bz2 \
+	    bms@freefall.freebsd.org:public_distfiles/
+.endif
+.endif
+
+.include <bsd.port.mk>

--- a/sysutils/pc-sysinstall/distinfo
+++ b/sysutils/pc-sysinstall/distinfo
@@ -1,0 +1,2 @@
+SHA256 (pc-sysinstall-9.1r21630.tar.bz2) = 3f11727d9fdfb07be99ec138fec7221ba8ca7172dce336a4fb74c7e2145ac95e
+SIZE (pc-sysinstall-9.1r21630.tar.bz2) = 56061

--- a/sysutils/pc-sysinstall/files/patch-pc-sysinstall-distfiles
+++ b/sysutils/pc-sysinstall/files/patch-pc-sysinstall-distfiles
@@ -1,0 +1,273 @@
+Index: usr.sbin/pc-sysinstall/backend/functions-extractimage.sh
+===================================================================
+--- usr.sbin/pc-sysinstall/backend/functions-extractimage.sh	(revision 241789)
++++ usr.sbin/pc-sysinstall/backend/functions-extractimage.sh	(working copy)
+@@ -29,23 +29,60 @@
+ 
+ . ${BACKEND}/functions-mountoptical.sh
+ 
++# Performs the extraction of data to disk from FreeBSD dist files
++start_extract_dist()
++{
++  if [ -z "$1" ] ; then exit_err "Called dist extraction with no directory set!"; fi
++  if [ -z "$INSFILE" ]; then exit_err "Called extraction with no install file set!"; fi
++  local DDIR="$1"
++
++  # Check if we are doing an upgrade, and if so use our exclude list
++  if [ "${INSTALLMODE}" = "upgrade" ]; then
++   TAROPTS="-X ${PROGDIR}/conf/exclude-from-upgrade"
++  else
++   TAROPTS=""
++  fi
++
++  # Loop though and extract dist files
++  for di in $INSFILE
++  do
++      # Check the MANIFEST see if we have an archive size / count
++      if [ -e "${DDIR}/MANIFEST" ]; then 
++         count=`grep "^${di}.txz" ${DDIR}/MANIFEST | awk '{print $3}'`
++	 if [ ! -z "$count" ] ; then
++            echo "INSTALLCOUNT: $count"
++	 fi
++      fi
++      echo_log "pc-sysinstall: Starting Extraction (${di})"
++      tar -xpv -C ${FSMNT} -f ${DDIR}/${di}.txz ${TAROPTS} >&1 2>&1
++      if [ $? -ne 0 ]; then
++        exit_err "ERROR: Failed extracting the dist file: $di"
++      fi
++  done
++
++  # Check if this was a FTP download and clean it up now
++  if [ "${INSTALLMEDIUM}" = "ftp" ]; then
++    echo_log "Cleaning up downloaded archives"
++    rm -rf ${DDIR}
++  fi
++
++  echo_log "pc-sysinstall: Extraction Finished"
++}
++
+ # Performs the extraction of data to disk from a uzip or tar archive
+ start_extract_uzip_tar()
+ {
+-  if [ -z "$INSFILE" ]
+-  then
++  if [ -z "$INSFILE" ]; then
+     exit_err "ERROR: Called extraction with no install file set!"
+   fi
+ 
+   # Check if we have a .count file, and echo it out for a front-end to use in progress bars
+-  if [ -e "${INSFILE}.count" ]
+-  then
++  if [ -e "${INSFILE}.count" ]; then
+     echo "INSTALLCOUNT: `cat ${INSFILE}.count`"
+   fi
+ 
+   # Check if we are doing an upgrade, and if so use our exclude list
+-  if [ "${INSTALLMODE}" = "upgrade" ]
+-  then
++  if [ "${INSTALLMODE}" = "upgrade" ]; then
+    TAROPTS="-X ${PROGDIR}/conf/exclude-from-upgrade"
+   else
+    TAROPTS=""
+@@ -87,9 +124,8 @@
+       mdconfig -d -u ${MDDEVICE}
+        ;;
+     tar)
+-	  tar -xpv -C ${FSMNT} -f ${INSFILE} ${TAROPTS} >&1 2>&1
+-      if [ $? -ne 0 ]
+-      then
++      tar -xpv -C ${FSMNT} -f ${INSFILE} ${TAROPTS} >&1 2>&1
++      if [ $? -ne 0 ]; then
+         exit_err "ERROR: Failed extracting the tar image"
+       fi
+       ;;
+@@ -176,6 +212,38 @@
+   echo_log "pc-sysinstall: Extraction Finished"
+ };
+ 
++# Function which will attempt to fetch the dist file(s) before we start
++fetch_dist_file()
++{
++  get_value_from_cfg ftpPath
++  if [ -z "$VAL" ]
++  then
++    exit_err "ERROR: Install medium was set to ftp, but no ftpPath was provided!" 
++  fi
++
++  FTPPATH="${VAL}"
++  
++  # Check if we have a /usr partition to save the download
++  if [ -d "${FSMNT}/usr" ]
++  then
++    DLDIR="${FSMNT}/usr/.fetch.$$"
++  else
++    DLDIR="${FSMNT}/.fetch.$$"
++  fi
++  mkdir -p ${DLDIR}
++
++  # Do the fetch of the dist archive(s) now
++  for di in $INSFILE
++  do
++    fetch_file "${FTPPATH}/${di}.txz" "${DLDIR}/${di}.txz" "1"
++  done
++
++  # Check to see if there is a MANIFEST file for this install
++  fetch_file "${FTPPATH}/MANIFEST" "${DLDIR}/MANIFEST" "0"
++
++  export DLDIR
++};
++
+ # Function which will attempt to fetch the install file before we start
+ # the install
+ fetch_install_file()
+@@ -390,6 +458,13 @@
+       case $PACKAGETYPE in
+         uzip) INSFILE="${FBSD_UZIP_FILE}" ;;
+         tar) INSFILE="${FBSD_TAR_FILE}" ;;
++        dist) 
++	  get_value_from_cfg_with_spaces distFiles
++	  if [ -z "$VAL" ] ; then
++	     exit_err "No dist files specified!"
++	  fi
++	  INSFILE="${VAL}" 
++  	  ;;
+         split)
+           INSDIR="${FBSD_BRANCH_DIR}"
+ 
+@@ -401,6 +476,13 @@
+       case $PACKAGETYPE in
+         uzip) INSFILE="${UZIP_FILE}" ;;
+         tar) INSFILE="${TAR_FILE}" ;;
++        dist) 
++	  get_value_from_cfg_with_spaces distFiles
++	  if [ -z "$VAL" ] ; then
++	     exit_err "No dist files specified!"
++	  fi
++	  INSFILE="${VAL}" 
++  	  ;;
+       esac
+     fi
+     export INSFILE
+@@ -417,22 +499,32 @@
+ 	    start_extract_split
+ 
+       else
+-        INSFILE="${CDMNT}/${INSFILE}" ; export INSFILE
+-        start_extract_uzip_tar
++	if [ "$PACKAGETYPE" = "dist" ] ; then
++          start_extract_dist "${CDMNT}/usr/freebsd-dist"
++	else
++          INSFILE="${CDMNT}/${INSFILE}" ; export INSFILE
++          start_extract_uzip_tar
++	fi
+       fi
+       ;;
+ 
+     ftp)
+-      if [ "$PACKAGETYPE" = "split" ]
+-      then
+-        fetch_split_files
++      case $PACKAGETYPE in
++	 split)
++           fetch_split_files
+ 
+-        INSDIR="${INSFILE}" ; export INSDIR
+-        start_extract_split
+-      else
+-        fetch_install_file
+-        start_extract_uzip_tar 
+-      fi
++           INSDIR="${INSFILE}" ; export INSDIR
++           start_extract_split
++	   ;;
++	  dist)
++           fetch_dist_file
++           start_extract_dist "$DLDIR"
++	   ;;
++	     *)
++           fetch_install_file
++           start_extract_uzip_tar 
++	   ;;
++       esac
+       ;;
+ 
+     sftp) ;;
+@@ -446,8 +538,13 @@
+         exit_err "Install medium was set to local, but no localPath was provided!"
+       fi
+       LOCALPATH=$VAL
+-      INSFILE="${LOCALPATH}/${INSFILE}" ; export INSFILE
+-      start_extract_uzip_tar
++      if [ "$PACKAGETYPE" = "dist" ] ; then
++        INSFILE="${LOCALPATH}/${INSFILE}" ; export INSFILE
++        start_extract_dist "$LOCALPATH"
++      else
++        INSFILE="${LOCALPATH}/${INSFILE}" ; export INSFILE
++        start_extract_uzip_tar
++      fi
+       ;;
+     *) exit_err "ERROR: Unknown install medium" ;;
+   esac
+Index: usr.sbin/pc-sysinstall/backend/functions-parse.sh
+===================================================================
+--- usr.sbin/pc-sysinstall/backend/functions-parse.sh	(revision 241789)
++++ usr.sbin/pc-sysinstall/backend/functions-parse.sh	(working copy)
+@@ -45,7 +45,7 @@
+ {
+   if [ -n "${1}" ]
+   then
+-    export VAL=`grep "^${1}=" ${CFGF} | head -n 1 | cut -d '=' -f 2-`
++    export VAL="`grep ^${1}= ${CFGF} | head -n 1 | cut -d '=' -f 2-`"
+   else
+     exit_err "Error: Did we forgot to supply a setting to grab?"
+   fi
+Index: usr.sbin/pc-sysinstall/backend/parseconfig.sh
+===================================================================
+--- usr.sbin/pc-sysinstall/backend/parseconfig.sh	(revision 241789)
++++ usr.sbin/pc-sysinstall/backend/parseconfig.sh	(working copy)
+@@ -69,7 +69,7 @@
+ check_value installMode "fresh upgrade extract"
+ check_value installType "PCBSD FreeBSD"
+ check_value installMedium "dvd usb ftp rsync image local"
+-check_value packageType "uzip tar rsync split"
++check_value packageType "uzip tar rsync split dist"
+ if_check_value_exists mirrorbal "load prefer round-robin split"
+ 
+ # We passed all sanity checks! Yay, lets start the install
+Index: usr.sbin/pc-sysinstall/examples/README
+===================================================================
+--- usr.sbin/pc-sysinstall/examples/README	(revision 241789)
++++ usr.sbin/pc-sysinstall/examples/README	(working copy)
+@@ -243,11 +243,16 @@
+ 
+ Available Types:
+   dvd - Search for and mount the DVD which contains the install archive
++local - Pull files directly from a local directory
+   usb - Search for and mount the USB drive which contains the install archive
+   ftp - The install archive will be fetched from a FTP / HTTP server before install
+ rsync - Pull the system data from a ssh + rsync server, specified with variables below
+ image - Install system from an image
+ 
++# localPath=/usr/freebsd-dist
++
++Location of the directory we will be pulling installation files from
++
+ # installType=(PCBSD, FreeBSD)
+ 
+ Set the type of system we are installing, PCBSD or FreeBSD
+@@ -256,10 +261,14 @@
+ 
+ The installer archive, if not using the defaults specified in conf/pc-sysinstall.conf
+ 
+-# packageType=(tar, uzip, split)
++# packageType=(tar, uzip, split, dist)
+ 
+ The archive type we are extracting from when using dvd, usb or ftp
+ 
++# distFiles=base src kernel
++
++List of dist files to install when packageType=dist
++
+ # ftpPath=ftp://ftp.pcbsd.org/pub/8.0/netinstall
+ 
+ Location of the installer archive when using a installMedium=ftp

--- a/sysutils/pc-sysinstall/files/pc-sysinstall.mtree
+++ b/sysutils/pc-sysinstall/files/pc-sysinstall.mtree
@@ -1,0 +1,15 @@
+# pc-sysinstall hierarchy
+.
+/set type=dir uname=root gname=wheel mode=0755
+            backend
+            ..
+	    backend-partmanager
+            ..
+	    backend-query
+            ..
+	    conf
+                license
+		..
+            ..
+	    doc
+            ..

--- a/sysutils/pc-sysinstall/pkg-descr
+++ b/sysutils/pc-sysinstall/pkg-descr
@@ -1,0 +1,2 @@
+This port produces a package of the pc-sysinstall utility, intended
+for use on older FreeBSD installations.

--- a/sysutils/pc-sysinstall/pkg-plist
+++ b/sysutils/pc-sysinstall/pkg-plist
@@ -1,0 +1,78 @@
+sbin/pc-sysinstall
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/README
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pc-autoinstall.conf
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pcinstall.cfg.fbsd-netinstall
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pcinstall.cfg.geli
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pcinstall.cfg.gmirror
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pcinstall.cfg.netinstall
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pcinstall.cfg.restore
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pcinstall.cfg.rsync
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pcinstall.cfg.upgrade
+%%PORTEXAMPLES%%%%EXAMPLESDIR%%/pcinstall.cfg.zfs
+%%DATADIR%%/backend-partmanager/create-part.sh
+%%DATADIR%%/backend-partmanager/delete-part.sh
+%%DATADIR%%/backend-query/detect-emulation.sh
+%%DATADIR%%/backend-query/detect-laptop.sh
+%%DATADIR%%/backend-query/detect-nics.sh
+%%DATADIR%%/backend-query/disk-info.sh
+%%DATADIR%%/backend-query/disk-list.sh
+%%DATADIR%%/backend-query/disk-part.sh
+%%DATADIR%%/backend-query/enable-net.sh
+%%DATADIR%%/backend-query/get-packages.sh
+%%DATADIR%%/backend-query/list-components.sh
+%%DATADIR%%/backend-query/list-config.sh
+%%DATADIR%%/backend-query/list-mirrors.sh
+%%DATADIR%%/backend-query/list-packages.sh
+%%DATADIR%%/backend-query/list-rsync-backups.sh
+%%DATADIR%%/backend-query/list-tzones.sh
+%%DATADIR%%/backend-query/query-langs.sh
+%%DATADIR%%/backend-query/send-logs.sh
+%%DATADIR%%/backend-query/set-mirror.sh
+%%DATADIR%%/backend-query/setup-ssh-keys.sh
+%%DATADIR%%/backend-query/sys-mem.sh
+%%DATADIR%%/backend-query/test-live.sh
+%%DATADIR%%/backend-query/test-netup.sh
+%%DATADIR%%/backend-query/update-part-list.sh
+%%DATADIR%%/backend-query/xkeyboard-layouts.sh
+%%DATADIR%%/backend-query/xkeyboard-models.sh
+%%DATADIR%%/backend-query/xkeyboard-variants.sh
+%%DATADIR%%/backend/functions-bsdlabel.sh
+%%DATADIR%%/backend/functions-cleanup.sh
+%%DATADIR%%/backend/functions-disk.sh
+%%DATADIR%%/backend/functions-extractimage.sh
+%%DATADIR%%/backend/functions-ftp.sh
+%%DATADIR%%/backend/functions-installcomponents.sh
+%%DATADIR%%/backend/functions-installpackages.sh
+%%DATADIR%%/backend/functions-localize.sh
+%%DATADIR%%/backend/functions-mountdisk.sh
+%%DATADIR%%/backend/functions-mountoptical.sh
+%%DATADIR%%/backend/functions-networking.sh
+%%DATADIR%%/backend/functions-newfs.sh
+%%DATADIR%%/backend/functions-packages.sh
+%%DATADIR%%/backend/functions-parse.sh
+%%DATADIR%%/backend/functions-runcommands.sh
+%%DATADIR%%/backend/functions-unmount.sh
+%%DATADIR%%/backend/functions-upgrade.sh
+%%DATADIR%%/backend/functions-users.sh
+%%DATADIR%%/backend/functions.sh
+%%DATADIR%%/backend/installimage.sh
+%%DATADIR%%/backend/parseconfig.sh
+%%DATADIR%%/backend/startautoinstall.sh
+%%DATADIR%%/conf/avail-langs
+%%DATADIR%%/conf/exclude-from-upgrade
+%%DATADIR%%/conf/license/bsd-en.txt
+%%DATADIR%%/conf/license/intel-en.txt
+%%DATADIR%%/conf/license/nvidia-en.txt
+%%DATADIR%%/conf/pc-sysinstall.conf
+%%DATADIR%%/doc/help-disk-list
+%%DATADIR%%/doc/help-disk-size
+%%DATADIR%%/doc/help-index
+%%DATADIR%%/doc/help-start-autoinstall
+@dirrm %%DATADIR%%/doc
+@dirrm %%DATADIR%%/conf/license
+@dirrm %%DATADIR%%/conf
+@dirrm %%DATADIR%%/backend-query
+@dirrm %%DATADIR%%/backend-partmanager
+@dirrm %%DATADIR%%/backend
+@dirrm %%DATADIR%%
+%%PORTEXAMPLES%%@dirrm %%EXAMPLESDIR%%


### PR DESCRIPTION
pc-sysinstall is a new installer for FreeBSD, with a number of advantages
over the legacy sysinstall installer.

The port makes pc-sysinstall more widely available. It can be used with older
FreeBSD releases, with an appropriate conversion script. It has been used
to perform network installs of FreeBSD 8.3 in a university protocol testbed.

Josh Paetzel will be maintainer.

Submitted by:   bms
Reviewed by:    eadler
