### PR TITLE
import RE patch from build82.dcjp02, including rc scripts and a workarou...

### DIFF
--- a/devel/buildbot-slave/Makefile
+++ b/devel/buildbot-slave/Makefile
@@ -7,6 +7,7 @@
 
 PORTNAME=	buildbot-slave
 PORTVERSION=	0.8.6p1
+PORTREVISION=	1
 CATEGORIES=	devel python
 MASTER_SITES=	GOOGLE_CODE
 
@@ -17,6 +18,12 @@ PROJECTHOST=	buildbot
 USE_PYTHON=	2.5+
 USE_PYDISTUTILS=	yes
 USE_TWISTED_RUN=	runner
+USE_RC_SUBR=	buildbot_slave
+
+BB_USER?=	www
+
+SUB_LIST=	BB_USER=${BB_USER} \
+		PYTHON_CMD=${PYTHON_CMD}
 
 post-patch:
 	@${FIND} ${WRKSRC} -type f | ${XARGS} -n 10 ${REINPLACE_CMD} -e \

--- a/devel/buildbot-slave/files/buildbot_slave.in
+++ b/devel/buildbot-slave/files/buildbot_slave.in
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+#
+# PROVIDE: buildbot_slave
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+#
+# Add the following line to /etc/rc.conf to enable buildbot-slave:
+#
+#  buildbot_slave_enable="YES"
+#  # optional
+#  buildbot_slave_config="%%PREFIX%%/buildbot/config/slave"
+#
+# This scripts takes one of the following commands:
+#
+#   start stop restart status
+#
+
+command=%%PREFIX%%/bin/buildslave
+command_interpreter=%%PYTHON_CMD%%
+
+. /etc/rc.subr
+
+load_rc_config buildbot_slave
+
+# set defaults
+buildbot_slave_enable=${buildbot_slave_enable:-"NO"}
+buildbot_slave_user=${buildbot_slave_user:-"%%BB_USER%%"}
+eval buildbot_slave_config=${buildbot_slave_config:-"~${buildbot_slave_user}/buildbot/config/slave"}
+
+name=buildbot_slave
+rcvar=`set_rcvar`
+
+start_cmd="buildbot_slave_command start"
+stop_cmd="buildbot_slave_command stop"
+restart_cmd="buildbot_slave_command restart"
+
+buildbot_slave_command()
+{
+    su -l ${buildbot_slave_user} -c "exec ${command} ${rc_arg} ${buildbot_slave_config}"
+}
+    
+run_rc_command "$1"

--- a/devel/buildbot/Makefile
+++ b/devel/buildbot/Makefile
@@ -7,6 +7,7 @@
 
 PORTNAME=	buildbot
 PORTVERSION=	0.8.6p1
+PORTREVISION=	1
 CATEGORIES=	devel python
 MASTER_SITES=	GOOGLE_CODE
 
@@ -21,6 +22,12 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}Jinja2>=2.1:${PORTSDIR}/devel/py-Jinja2 \
 USE_PYTHON=	2.5+
 USE_PYDISTUTILS=	yes
 USE_TWISTED_RUN=	conch mail web words
+USE_RC_SUBR=	buildbot
+
+BB_USER?=	www
+
+SUB_LIST=	BB_USER=${BB_USER} \
+		PYTHON_CMD=${PYTHON_CMD}
 
 post-patch:
 	@${FIND} ${WRKSRC} -type f | ${XARGS} -n 10 ${REINPLACE_CMD} -e \

--- a/devel/buildbot/files/buildbot.in
+++ b/devel/buildbot/files/buildbot.in
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+#
+# PROVIDE: buildbot
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+#
+# Add the following line to /etc/rc.conf to enable buildbot:
+#
+#  buildbot_enable="YES"
+#  # optional
+#  buildbot_config="%%PREFIX%%/buildbot/config/master"
+#
+# This scripts takes one of the following commands:
+#
+#   start stop restart status
+#
+
+command=%%PREFIX%%/bin/buildbot
+command_interpreter=%%PYTHON_CMD%%
+
+. /etc/rc.subr
+
+load_rc_config buildbot
+
+# set defaults
+buildbot_enable=${buildbot_enable:-"NO"}
+buildbot_user=${buildbot_user:-"%%BB_USER%%"}
+eval buildbot_config=${buildbot_config:-"~${buildbot_user}/buildbot/config/master"}
+
+name=buildbot
+rcvar=`set_rcvar`
+
+extra_commands="reload"
+
+start_cmd="buildbot_command start"
+stop_cmd="buildbot_command stop"
+restart_cmd="buildbot_command restart"
+
+buildbot_command()
+{
+    su -l ${buildbot_user} -c "exec ${command} ${rc_arg} ${buildbot_config}"
+}
+    
+run_rc_command "$1"

--- a/devel/buildbot/files/patch-buildbot__changes__manager.py
+++ b/devel/buildbot/files/patch-buildbot__changes__manager.py
@@ -1,0 +1,11 @@
+--- ./buildbot/changes/manager.py.orig	2012-10-19 16:37:15.000000000 +0900
++++ ./buildbot/changes/manager.py	2012-10-22 15:43:23.000000000 +0900
+@@ -65,7 +65,7 @@
+                 src.setServiceParent(self)
+ 
+         num_sources = len(list(self))
+-        assert num_sources == len(new_config.change_sources)
++#        assert num_sources == len(new_config.change_sources)
+         metrics.MetricCountEvent.log("num_sources", num_sources, absolute=True)
+ 
+         # reconfig any newly-added change sources, as well as existing


### PR DESCRIPTION
...nd

commit 6904a77e638801db93b3e785ba97005c201d5944
Author: Mitsuru Y mitsuruy@reallyenglish.com
Date:   Tue Oct 23 16:03:02 2012 +0900

```
disable assertion in changes/manager.py for backward compatibility

assertion was introduced at 0.8.6 and it may break backward compatibility
as it fails in REs environment.
This is a workaround and should be fixed later.
```
