### PR TITLE
create logstash user

### DIFF
--- a/GIDs
+++ b/GIDs
@@ -182,6 +182,7 @@ freeswitch:*:610:
 monkeysphere:*:641:
 aox:*:666:
 bnetd:*:700:
+logstash:*:701:
 bopm:*:717:
 openxpki:*:777:
 puppet:*:814:

--- a/UIDs
+++ b/UIDs
@@ -188,6 +188,7 @@ _pla:*:636:80::0:0:phpLDAPAdmin Owner:/nonexistent:/usr/sbin/nologin
 monkeysphere:*:641:641::0:0:Monkeysphere User:/var/monkeysphere:/usr/local/bin/bash
 aox:*:666:666::0:0:Archiveopteryx user:/nonexistent:/usr/sbin/nologin
 bnetd:*:700:700::0:0:Bnetd user:/nonexistent:/usr/sbin/nologin
+logstash:*:701:701::0:0:logstash user:/nonexistent:/usr/sbin/nologin
 bopm:*:717:717::0:0:Blitzed Open Proxy Monitor:/nonexistent:/bin/sh
 openxpki:*:777:777::0:0:OpenXPKI Owner:/nonexistent:/usr/sbin/nologin
 puppet:*:814:814::0:0:Puppet Daemon:/nonexistent:/usr/sbin/nologin

--- a/sysutils/logstash/Makefile
+++ b/sysutils/logstash/Makefile
@@ -6,12 +6,11 @@
 #
 
 # TODO
-# - UIDs/GIDs
 # - DOCs
 # 
 PORTNAME=	logstash
 PORTVERSION=	1.1.12
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	sysutils java
 MASTER_SITES=	https://logstash.objects.dreamhost.com/release/
 DISTNAME=	${PORTNAME}-${PORTVERSION}-flatjar
@@ -27,6 +26,8 @@ JAVA_VERSION=	1.7+
 NO_BUILD=	yes
 
 USE_RC_SUBR=	logstash
+USERS=	${PORTNAME}
+GROUPS=	${PORTNAME}
 
 LOGSTASH_HOME?=	${PREFIX}/${PORTNAME}
 LOGSTASH_HOME_REL?=	${LOGSTASH_HOME:S,^${PREFIX}/,,}


### PR DESCRIPTION
UID 701 was choosen because:
- new user will get 9xx assigned in the upstream and collides
- it's unlikely that lmp (701 in /etc/services) will be used
