### PR TITLE
export TMPDIR

### DIFF
--- a/sysutils/logstash/Makefile
+++ b/sysutils/logstash/Makefile
@@ -10,7 +10,7 @@
 # 
 PORTNAME=	logstash
 PORTVERSION=	1.1.12
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	sysutils java
 MASTER_SITES=	https://logstash.objects.dreamhost.com/release/
 DISTNAME=	${PORTNAME}-${PORTVERSION}-flatjar

--- a/sysutils/logstash/files/logstash.in
+++ b/sysutils/logstash/files/logstash.in
@@ -60,11 +60,13 @@ load_rc_config "${name}"
 : ${logstash_java_flags="-Des.path.data=${logstash_elastic_datadir}"}
 : ${logstash_user="logstash"}
 : ${logstash_group="logstash"}
+: ${logstash_tmpdir="/tmp"}
 
 java_cmd="${logstash_java_home}/bin/java"
 procname="${java_cmd}"
 
 logstash_chdir=${logstash_home}
+export TMPDIR="${logstash_tmpdir}"
 
 if [ -z "${logstash_agent_flags}" ]; then
     if [ ${logstash_mode} == "standalone" ]; then


### PR DESCRIPTION
"Unable to find a non world-writable directory for tmpdir. Consider
setting ENV['TMPDIR'], ENV['TMP'] or ENV['TEMP'] to a non world-writable
directory."
