### PR TITLE
introduce devel/rubygem-ffi-rzmq

### DIFF
--- a/devel/rubygem-ffi-rzmq/Makefile
+++ b/devel/rubygem-ffi-rzmq/Makefile
@@ -1,0 +1,19 @@
+# Created by: Tomoyuki Sakurai <tomoyukis@reallyenglish.com>
+# $FreeBSD$
+
+PORTNAME=	ffi-rzmq
+PORTVERSION=	1.0.1
+#PORTREVISION=	0
+CATEGORIES=	devel rubygems
+MASTER_SITES=	RG
+
+MAINTAINER=	tomoyukis@reallyenglish.com
+COMMENT=	ZeroMQ library for ruby using FFI
+
+RUN_DEPENDS=	rubygem-ffi>=0:${PORTSDIR}/devel/rubygem-ffi
+
+USE_RUBY=	yes
+USE_RUBYGEMS=	yes
+RUBYGEM_AUTOPLIST=	yes
+
+.include <bsd.port.mk>

--- a/devel/rubygem-ffi-rzmq/distinfo
+++ b/devel/rubygem-ffi-rzmq/distinfo
@@ -1,0 +1,2 @@
+SHA256 (rubygem/ffi-rzmq-1.0.1.gem) = 7763bca762131834e904be41ab74a57a69662c68ad7933a87cbf836cbd82e238
+SIZE (rubygem/ffi-rzmq-1.0.1.gem) = 50176

--- a/devel/rubygem-ffi-rzmq/pkg-descr
+++ b/devel/rubygem-ffi-rzmq/pkg-descr
@@ -1,0 +1,6 @@
+s gem wraps the ZeroMQ networking library using the ruby FFI (foreign function
+interface). It's a pure ruby wrapper so this gem can be loaded and run by any
+ruby runtime that supports FFI. That's all of the major ones - MRI, Rubinius
+and JRuby.
+
+WWW: http://github.com/chuckremes/ffi-rzmq

--- a/devel/rubygem-ffi-rzmq/pkg-plist
+++ b/devel/rubygem-ffi-rzmq/pkg-plist
@@ -1,0 +1,1 @@
+@comment $FreeBSD$


### PR DESCRIPTION
required by logstash's zeromq input plugin
