### PR TITLE
bugfix: fix uninitialized constant Chef::ConfigFetcher

### DIFF
--- a/sysutils/rubygem-chef-solr/Makefile
+++ b/sysutils/rubygem-chef-solr/Makefile
@@ -3,7 +3,7 @@
 
 PORTNAME=	chef-solr
 PORTVERSION=	11.0.0
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	sysutils
 MASTER_SITES=	RG
 
@@ -25,5 +25,9 @@ PLIST_FILES=	bin/chef-solr \
 DISTVERSIONSUFFIX=	.alpha.1
 GEM_NAME=	${PORTNAME}-${PORTVERSION}${DISTVERSIONSUFFIX}
 MASTER_SITE_RUBYGEMS=	http://dist.reallyenglish.com/pub/gems/%SUBDIR%/
+
+post-install:
+	${PATCH} -p0 -d ${PREFIX}/${GEM_LIB_DIR} < ${PATCHDIR}/configfetcher.patch
+	@${FIND} ${PREFIX}/${GEM_LIB_DIR} -name "*.orig" -delete
 
 .include <bsd.port.mk>

--- a/sysutils/rubygem-chef-solr/files/configfetcher.patch
+++ b/sysutils/rubygem-chef-solr/files/configfetcher.patch
@@ -1,0 +1,11 @@
+--- lib/chef/solr/application/solr.rb.orig  2013-11-22 16:45:43.000000000 +0900
++++ lib/chef/solr/application/solr.rb   2013-11-22 16:45:57.000000000 +0900
+@@ -22,6 +22,7 @@
+ require 'chef/application'
+ require 'chef/daemon'
+ require 'chef/solr'
++require 'chef/config_fetcher'
+ 
+ class Chef
+   class Solr
+


### PR DESCRIPTION
/usr/local/lib/ruby/gems/1.9/gems/chef-11.8.0/lib/chef/application.rb:77:in
`load_config_file': uninitialized constant Chef::ConfigFetcher
(NameError)
