### PR TITLE
update to 1.10.2

### DIFF
--- a/devel/rubygem-mongo/Makefile
+++ b/devel/rubygem-mongo/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	mongo
-PORTVERSION=	1.9.2
+PORTVERSION=	1.10.2
 CATEGORIES=	devel rubygems
 MASTER_SITES=	RG
 

--- a/devel/rubygem-mongo/distinfo
+++ b/devel/rubygem-mongo/distinfo
@@ -1,2 +1,2 @@
-SHA256 (rubygem/mongo-1.9.2.gem) = 958ae3cdfb5727fd7c37d0dcacda82f3edbc53f8b90cff0707c09ce4b05444e5
-SIZE (rubygem/mongo-1.9.2.gem) = 132608
+SHA256 (rubygem/mongo-1.10.2.gem) = f5ae848194d6d15207ed9f54b2d9e4861e47c1a9c0afee9038f2e82affa8e267
+SIZE (rubygem/mongo-1.10.2.gem) = 164352


### PR DESCRIPTION
because devel/rubygem-bson is 2.x but rubygem-mongo requires 1.9.2
