### PR TITLE
checkout 288beee -- www/rt38 for security fix

### DIFF
--- a/www/rt38/Makefile
+++ b/www/rt38/Makefile
@@ -8,12 +8,12 @@
 #   o install a sample into etc/apache22/Includes
 
 PORTNAME=	rt
-PORTVERSION=	3.8.16
+PORTVERSION=	3.8.17
 CATEGORIES=	www
 MASTER_SITES=	http://download.bestpractical.com/pub/rt/release/ \
 		ftp://ftp.eu.uu.net/pub/unix/ticketing/rt/release/
 
-MAINTAINER=	ports@FreeBSD.org
+MAINTAINER=	flo@FreeBSD.org
 COMMENT=	RT is an industrial-grade ticketing system written in Perl
 
 CONFLICTS=	rt-4.0* brlcad-[0-9]*

--- a/www/rt38/distinfo
+++ b/www/rt38/distinfo
@@ -1,2 +1,2 @@
-SHA256 (rt-3.8.16.tar.gz) = 8a0bdb9fc2938ffe21111127d5777ef5d3107195c2597cb35c5c0a44dc4ca045
-SIZE (rt-3.8.16.tar.gz) = 5650272
+SHA256 (rt-3.8.17.tar.gz) = d9cd8b239712f25d38619791ab9f8d60c57f001cc0df2caeb2ccb7ad9f8a4acd
+SIZE (rt-3.8.17.tar.gz) = 5728368


### PR DESCRIPTION
commit 288beeed25da9d11bebca23c10a87b41cb2779a5
Author: matthew matthew@FreeBSD.org
Date:   Thu May 23 07:24:40 2013 +0000

```
Security Updates

   - www/rt40 to 4.0.13
   - www/rt38 to 3.8.17 [1]

This is a security fix addressing a number of CVEs:

    CVE-2012-4733
    CVE-2013-3368
    CVE-2013-3369
    CVE-2013-3370
    CVE-2013-3371
    CVE-2013-3372
    CVE-2013-3373
    CVE-2013-3374

Users will need to update their database schemas as described in
pkg-message

Approved by:        flo [1]
Security:   3a429192-c36a-11e2-97a9-6805ca0b3d42
```
