### PR TITLE
downgrade to 20140509 with our own patches

### DIFF
--- a/devel/ruby-build/Makefile
+++ b/devel/ruby-build/Makefile
@@ -1,26 +1,37 @@
 # $FreeBSD$
 
 PORTNAME=	ruby-build
-PORTVERSION=	20141028
+PORTVERSION=	20140509.1
 CATEGORIES=	devel ruby
+MASTER_SITES=	GH
 
-MAINTAINER=	meta+ports@vmeta.jp
+MAINTAINER=	fmb@onibox.net
 COMMENT=	Compile and install different ruby versions
 
-LICENSE=	MIT
+LICENSE=	RUBY-BUILD
+LICENSE_NAME=	Sam Stephenson
+LICENSE_FILE=	${WRKSRC}/LICENSE
+LICENSE_PERMS=${_LICENSE_PERMS_DEFAULT}
 
 RUN_DEPENDS=	autoconf:${PORTSDIR}/devel/autoconf \
-		curl:${PORTSDIR}/ftp/curl \
-		gmake:${PORTSDIR}/devel/gmake
+		curl:${PORTSDIR}/ftp/curl
+
+USE_GCC=	4.6
+USES=	gmake
 
 OPTIONS_DEFINE=	RBENV
 RBENV_DESC=	Install rbenv for installation support
 OPTIONS_DEFAULT=	RBENV
-RBENV_RUN_DEPENDS=	rbenv:${PORTSDIR}/devel/rbenv
+
+.include <bsd.port.options.mk>
+
+.if ${PORT_OPTIONS:MRBENV}
+RUN_DEPENDS+=	rbenv:${PORTSDIR}/devel/rbenv
+.endif
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	sstephenson
-GH_COMMIT=	81807c6
+GH_COMMIT=	9aece39
 GH_TAGNAME=	v${PORTVERSION}
 
 NO_BUILD=	yes

--- a/devel/ruby-build/distinfo
+++ b/devel/ruby-build/distinfo
@@ -1,2 +1,2 @@
-SHA256 (ruby-build-20141028.tar.gz) = fca94d23dd7473a26c1cf2ae8ad68a8312c5ed70559aba287968fd17c5b836aa
-SIZE (ruby-build-20141028.tar.gz) = 37242
+SHA256 (ruby-build-20140509.1.tar.gz) = 5511b79e1fc8514323b03c25306a284fc4d5a5ae460586366452b1ba7aeb64cc
+SIZE (ruby-build-20140509.1.tar.gz) = 28613

--- a/devel/ruby-build/files/patch-bin__rbenv-install
+++ b/devel/ruby-build/files/patch-bin__rbenv-install
@@ -1,0 +1,13 @@
+--- bin/rbenv-install.orig	2014-05-09 03:51:19 UTC
++++ bin/rbenv-install
+@@ -33,6 +33,10 @@ if [ -z "$RBENV_ROOT" ]; then
+   RBENV_ROOT="${HOME}/.rbenv"
+ fi
+ 
++if [ `uname -s` = "FreeBSD" ]; then
++  export MAKE="gmake"
++fi
++
+ # Load shared library functions
+ eval "$(ruby-build --lib)"
+ 

--- a/devel/ruby-build/files/patch-bin__ruby-build
+++ b/devel/ruby-build/files/patch-bin__ruby-build
@@ -1,0 +1,48 @@
+--- bin/ruby-build.orig	2014-05-09 03:51:19 UTC
++++ bin/ruby-build
+@@ -181,6 +181,13 @@ compute_md5() {
+ }
+ 
+ verify_checksum() {
++  # disable verify_checksum because:
++  # - recent tinderbox does not allow fetching remote file during build
++  # - DISTDIR must be used as mirror
++  # - DISTDIR does not contain checksum file
++  # - checksum is verified by the ports framework
++  return 0
++
+   # If there's no MD5 support, return success
+   [ -n "$HAS_MD5_SUPPORT" ] || return 0
+ 
+@@ -256,11 +263,21 @@ fetch_tarball() {
+   local tar_args="xzvf"
+   local package_filename="${package_name}.tar.gz"
+ 
++  # XXX a terrible hack to fix suffix
++  local package_name_without_version=`echo ${package_name} | cut -f1 -d"-"`
++  if [ x${package_name_without_version} == x"rubygems" ]; then
++    package_filename="${package_name}.tgz"
++  fi
++
+   if [ "$package_url" != "${package_url%bz2}" ]; then
+     package_filename="${package_filename%.gz}.bz2"
+     tar_args="${tar_args/z/j}"
+   fi
+ 
++  if [ -n "$RUBY_BUILD_MIRROR_URL" ]; then
++    mirror_url="${RUBY_BUILD_MIRROR_URL}/${package_filename}"
++  fi
++
+   if ! reuse_existing_tarball "$package_filename" "$checksum"; then
+     local tarball_filename=$(basename $package_url)
+     echo "Downloading ${tarball_filename}..." >&2
+@@ -688,7 +705,8 @@ gccs_in_path() {
+ 
+   shopt -s nullglob
+   for path in "${paths[@]}"; do
+-    for gcc in "$path"/gcc-*; do
++    # file name of gcc 4.6 is gcc46, not gcc-46
++    for gcc in "$path"/gcc*; do
+       gccs["${#gccs[@]}"]="$gcc"
+     done
+   done


### PR DESCRIPTION
because i do not have enough time to disable checksum routines in
rbenv-install. further more, i just do not want to use ruby-build as it
conflicts with package management system in so many ways (fetches files
during build, check the checksum in own way, does not maintain fixes
found in the official package management system, does not respect
PREFIX, you name it).
