### PR TITLE
New port: sysutils/rubygem-syslog-logger; imported from build82

### DIFF
--- a/sysutils/Makefile
+++ b/sysutils/Makefile
@@ -853,6 +853,7 @@
     SUBDIR += rubygem-sys-proctable
     SUBDIR += rubygem-sys-uname
     SUBDIR += rubygem-sys-uptime
+    SUBDIR += rubygem-syslog-logger
     SUBDIR += rubygem-teamocil
     SUBDIR += runit
     SUBDIR += runwhen

--- a/sysutils/rubygem-syslog-logger/Makefile
+++ b/sysutils/rubygem-syslog-logger/Makefile
@@ -1,0 +1,19 @@
+# Created by: Tomoyuki Sakurai <tomoyukis@reallyenglish.com>
+# $FreeBSD$
+
+PORTNAME=	syslog-logger
+PORTVERSION=	1.6.8
+#PORTREVISION=	0
+CATEGORIES=	sysutils
+MASTER_SITES=	RG
+
+MAINTAINER=	tomoyukis@reallyenglish.com
+COMMENT=	Improved Logger replacement that logs to syslog
+
+LICENSE=	MIT
+
+USE_RUBY=	Yes
+USE_RUBYGEMS=	Yes
+RUBYGEM_AUTOPLIST=	Yes
+
+.include <bsd.port.mk>

--- a/sysutils/rubygem-syslog-logger/distinfo
+++ b/sysutils/rubygem-syslog-logger/distinfo
@@ -1,0 +1,2 @@
+SHA256 (rubygem/syslog-logger-1.6.8.gem) = 7541f34681c7d10ed63e8ee82733b0a60f79264a6ef3f489a20dce80e105c293
+SIZE (rubygem/syslog-logger-1.6.8.gem) = 9216

--- a/sysutils/rubygem-syslog-logger/pkg-descr
+++ b/sysutils/rubygem-syslog-logger/pkg-descr
@@ -1,0 +1,4 @@
+An improved Logger replacement that logs to syslog. It is almost drop-in with a
+few caveats.
+
+WWW: http://rubygems.org/gems/syslog-logger

--- a/sysutils/rubygem-syslog-logger/pkg-plist
+++ b/sysutils/rubygem-syslog-logger/pkg-plist
@@ -1,0 +1,1 @@
+@comment $FreeBSD$


### PR DESCRIPTION
commit 71ca25e6e8e2852f8c22a584744e1dd69d26eedd
Author: Mitsuru Y <mitsuruy@reallyenglish.com>
Date:   Mon Jan 5 15:42:27 2015 +0900

    Update port: sysutils/rubygem-syslog-logger to 1.6.8

commit 0032b5d079337cd5f85aeb47d98af92132cb9a5c
Author: Tomoyuki Sakurai <tomoyukis@reallyenglish.com>
Date:   Thu Aug 25 10:37:09 2011 +0900

    add new rubygem for syslogging

    can be used in client.rb like:

    require 'syslog_logger'
    Chef::Log.logger = SyslogLogger.new